### PR TITLE
Include snippets in package

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -6,6 +6,15 @@ Changelog
 Version 0 (Beta)
 ----------------
 
+0.1.1 (2018-Dec-28)
+===================
+
+Bug Fixes
+---------
+
+* Adding the ``snippets`` folder to the PyPI package - was not included
+  in previous build.
+
 0.1.0 (2018-Dec-26)
 ===================
 

--- a/setup.py
+++ b/setup.py
@@ -22,6 +22,7 @@ setup(
     package_data={
         'subscriptions': [
             'templates/subscriptions/*.html',
+            'templates/subscriptions/snippets/*.html',
         ]
     },
     project_urls={

--- a/subscriptions/__init__.py
+++ b/subscriptions/__init__.py
@@ -1,5 +1,5 @@
 # pylint: disable=missing-docstring, invalid-name
-__version__ = '0.1.0'
+__version__ = '0.1.1'
 
 # Provide DepreciationWarning for older Django versions
 import warnings


### PR DESCRIPTION
The snippets folder wasn't include in previous PyPI builds.