### PR TITLE
Fixed DSF_ENABLE_ADMIN not working issue in admin.py

### DIFF
--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -11,7 +11,7 @@ Admin Settings
 
 These are settings to control aspects of the Django admin support.
 
-``DSF_ENABLE_ADMIN``
+``DFS_ENABLE_ADMIN``
 ====================
 
 **Required:** ``False``
@@ -26,7 +26,7 @@ Currency Settings
 
 These are the settings to control aspects of currency repsentation.
 
-``DSF_CURRENCY_LOCALE``
+``DFS_CURRENCY_LOCALE``
 =======================
 
 **Required:** ``False``
@@ -62,7 +62,7 @@ allows you to easily specify the main site design for the provided
 Django Flexible Subscription views. The template must include a
 ``content`` block, which is what all the templates override.
 
-``DSF_SUBSCRIBE_VIEW``
+``DFS_SUBSCRIBE_VIEW``
 ======================
 
 **Required:** ``False``

--- a/sandbox/settings.py
+++ b/sandbox/settings.py
@@ -117,6 +117,6 @@ STATIC_ROOT = ROOT_DIR.path('static')
 
 # django-flexible-subscriptions settings
 # -----------------------------------------------------------------------------
-DSF_CURRENCY_LOCALE = 'en_ca'
-DSF_ENABLE_ADMIN = True
+DFS_CURRENCY_LOCALE = 'en_ca'
+DFS_ENABLE_ADMIN = True
 DFS_BASE_TEMPLATE = 'subscriptions/base.html'

--- a/subscriptions/admin.py
+++ b/subscriptions/admin.py
@@ -65,5 +65,6 @@ class TransactionAdmin(admin.ModelAdmin):
 
 if settings.DSF_ENABLE_ADMIN:
     admin.site.register(models.SubscriptionPlan, SubscriptionPlanAdmin)
+    admin.site.register(models.PlanList, PlanListAdmin)
     admin.site.register(models.UserSubscription, UserSubscriptionAdmin)
     admin.site.register(models.SubscriptionTransaction, TransactionAdmin)

--- a/subscriptions/admin.py
+++ b/subscriptions/admin.py
@@ -2,7 +2,7 @@
 from django.contrib import admin
 
 from subscriptions import models
-from django.conf import settings
+from subscriptions.conf import SETTINGS
 
 
 class SubscriptionPlanAdmin(admin.ModelAdmin):
@@ -19,27 +19,6 @@ class SubscriptionPlanAdmin(admin.ModelAdmin):
         'group',
         'display_tags',
     ]
-
-class SubscriptionPlanInlineAdmin(admin.TabularInline):
-    """Admin inline class for the SubscriptionPlan model."""
-    model = models.PlanList.plans.through
-
-class PlanListAdmin(admin.ModelAdmin):
-    """Admin class for the PlanList model."""
-    fields = [
-        'title',
-        'subtitle',
-        'active'
-    ]
-    list_display = [
-        'title',
-        'subtitle',
-        'header',
-        'footer',
-        'active'
-    ]
-
-    inlines = (SubscriptionPlanInlineAdmin,)
 
 class UserSubscriptionAdmin(admin.ModelAdmin):
     """Admin class for the UserSubscription model."""
@@ -63,8 +42,7 @@ class UserSubscriptionAdmin(admin.ModelAdmin):
 class TransactionAdmin(admin.ModelAdmin):
     """Admin class for the SubscriptionTransaction model."""
 
-if settings.DSF_ENABLE_ADMIN:
+if SETTINGS['enable_admin']:
     admin.site.register(models.SubscriptionPlan, SubscriptionPlanAdmin)
-    admin.site.register(models.PlanList, PlanListAdmin)
     admin.site.register(models.UserSubscription, UserSubscriptionAdmin)
     admin.site.register(models.SubscriptionTransaction, TransactionAdmin)

--- a/subscriptions/admin.py
+++ b/subscriptions/admin.py
@@ -20,6 +20,27 @@ class SubscriptionPlanAdmin(admin.ModelAdmin):
         'display_tags',
     ]
 
+class SubscriptionPlanInlineAdmin(admin.TabularInline):
+    """Admin inline class for the SubscriptionPlan model."""
+    model = models.PlanList.plans.through
+
+class PlanListAdmin(admin.ModelAdmin):
+    """Admin class for the PlanList model."""
+    fields = [
+        'title',
+        'subtitle',
+        'active'
+    ]
+    list_display = [
+        'title',
+        'subtitle',
+        'header',
+        'footer',
+        'active'
+    ]
+
+    inlines = (SubscriptionPlanInlineAdmin,)
+
 class UserSubscriptionAdmin(admin.ModelAdmin):
     """Admin class for the UserSubscription model."""
     fields = [

--- a/subscriptions/admin.py
+++ b/subscriptions/admin.py
@@ -2,7 +2,7 @@
 from django.contrib import admin
 
 from subscriptions import models
-from subscriptions.conf import SETTINGS
+from django.conf import settings
 
 
 class SubscriptionPlanAdmin(admin.ModelAdmin):
@@ -24,8 +24,6 @@ class UserSubscriptionAdmin(admin.ModelAdmin):
     """Admin class for the UserSubscription model."""
     fields = [
         'user',
-        'plan',
-        'payment_method',
         'date_billing_start',
         'date_billing_end',
         'date_billing_last',
@@ -35,7 +33,6 @@ class UserSubscriptionAdmin(admin.ModelAdmin):
     ]
     list_display = [
         'user',
-        'plan',
         'date_billing_last',
         'date_billing_next',
         'active',
@@ -45,7 +42,7 @@ class UserSubscriptionAdmin(admin.ModelAdmin):
 class TransactionAdmin(admin.ModelAdmin):
     """Admin class for the SubscriptionTransaction model."""
 
-if SETTINGS['enable_admin']:
+if settings.DSF_ENABLE_ADMIN:
     admin.site.register(models.SubscriptionPlan, SubscriptionPlanAdmin)
     admin.site.register(models.UserSubscription, UserSubscriptionAdmin)
     admin.site.register(models.SubscriptionTransaction, TransactionAdmin)


### PR DESCRIPTION
Registration didn't work because of the following:

- Wrong settings import and wrong reference method use in if statement. Replaced them with proper ones.
- Err occured because of unknown field in fields and list_fields array. Deleted plans and payment method from both of them.

Resolves: #28