### PR TITLE
Fix form error triggering

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -3,32 +3,39 @@ name = "pypi"
 url = "https://pypi.org/simple"
 verify_ssl = true
 
+
 [packages]
 django = "*"  # https://github.com/django/django
+
 
 [dev-packages]
 # Django (for testing)
 # ------------------------------------------------------------------------------
 django-environ = "*"  # https://github.com/joke2k/django-environ
 django-debug-toolbar = "*"  # https://github.com/jazzband/django-debug-toolbar
+
 # Code quality
 # ------------------------------------------------------------------------------
 coverage = "*"  # https://github.com/nedbat/coveragepy
 pylint = "*"  # https://github.com/PyCQA/pylint/
 pylint-django = "*"  # https://github.com/PyCQA/pylint-django
 restructuredtext-lint = "*"  # https://github.com/twolfson/restructuredtext-lint
+
 # Testing
 # ------------------------------------------------------------------------------
+factory_boy = "*"  # https://github.com/FactoryBoy/factory_boy
 pytest = "*"  # https://github.com/pytest-dev/pytest
 pytest-cov = "*"  # https://github.com/pytest-dev/pytest-cov
 pytest-django = "*"  # https://pytest-django.readthedocs.io/en/latest/
 tox = "==3.7.0"  # https://github.com/tox-dev/tox/
 tox-pipenv = "*"  # https://github.com/tox-dev/tox-pipenv
 tox-travis = "*"  # https://github.com/tox-dev/tox-travis
+
 # Package Documentation
 # ------------------------------------------------------------------------------
 sphinx = "*"  # https://github.com/sphinx-doc/sphinx
 sphinx_rtd_theme = "*"  # https://github.com/rtfd/sphinx_rtd_theme
+
 # Package Distribution
 # ------------------------------------------------------------------------------
 setuptools = "*"  # https://pypi.org/project/setuptools/#description

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "024ce157c48fa0d6f6312aef4199493ba6b2cc705f67dcc0b77c6661d7229ce8"
+            "sha256": "ee254ba36f3017fe5f55b01ac0d5f527c54260909a1a037ec71f672b3e0c4eed"
         },
         "pipfile-spec": 6,
         "requires": {},
@@ -171,6 +171,21 @@
                 "sha256:a2aeea129088da402665e92e0b25b04b073c04b2dce4ab65caaa38b7ce2e1a99"
             ],
             "version": "==0.15.2"
+        },
+        "factory-boy": {
+            "hashes": [
+                "sha256:728df59b372c9588b83153facf26d3d28947fc750e8e3c95cefa9bed0e6394ee",
+                "sha256:faf48d608a1735f0d0a3c9cbf536d64f9132b547dae7ba452c4d99a79e84a370"
+            ],
+            "index": "pypi",
+            "version": "==2.12.0"
+        },
+        "faker": {
+            "hashes": [
+                "sha256:96ad7902706f2409a2d0c3de5132f69b413555a419bacec99d3f16e657895b47",
+                "sha256:b3bb64aff9571510de6812df45122b633dbc6227e870edae3ed9430f94698521"
+            ],
+            "version": "==2.0.0"
         },
         "filelock": {
             "hashes": [
@@ -380,6 +395,13 @@
             "index": "pypi",
             "version": "==3.5.1"
         },
+        "python-dateutil": {
+            "hashes": [
+                "sha256:7e6584c74aeed623791615e26efd690f29817a27c73085b78e4bad02493df2fb",
+                "sha256:c89805f6f4d64db21ed966fda138f8a5ed7a4fdbc1a8ee329ce1b74e3c74da9e"
+            ],
+            "version": "==2.8.0"
+        },
         "pytz": {
             "hashes": [
                 "sha256:26c0b32e437e54a18161324a2fca3c4b9846b74a8dccddd843113109e1116b32",
@@ -492,6 +514,13 @@
                 "sha256:7c3dca29c022744e95b547e867cee89f4fce4373f3549ccd8797d8eb52cdb873"
             ],
             "version": "==0.3.0"
+        },
+        "text-unidecode": {
+            "hashes": [
+                "sha256:5a1375bb2ba7968740508ae38d92e1f889a0832913cb1c447d5e2046061a396d",
+                "sha256:801e38bd550b943563660a91de8d4b6fa5df60a542be9093f7abf819f86050cc"
+            ],
+            "version": "==1.2"
         },
         "toml": {
             "hashes": [

--- a/subscriptions/migrations/0003_update_plan_list_detail.py
+++ b/subscriptions/migrations/0003_update_plan_list_detail.py
@@ -25,7 +25,7 @@ class Migration(migrations.Migration):
             name='plan',
             field=models.ForeignKey(
                 on_delete=django.db.models.deletion.CASCADE,
-                related_name='plan_list_detail',
+                related_name='plan_list_details',
                 to='subscriptions.SubscriptionPlan'
             ),
         ),

--- a/subscriptions/models.py
+++ b/subscriptions/models.py
@@ -323,7 +323,7 @@ class PlanListDetail(models.Model):
     plan = models.ForeignKey(
         SubscriptionPlan,
         on_delete=models.CASCADE,
-        related_name='plan_list_detail',
+        related_name='plan_list_details',
     )
     plan_list = models.ForeignKey(
         PlanList,

--- a/subscriptions/views.py
+++ b/subscriptions/views.py
@@ -788,7 +788,6 @@ class SubscribeView(LoginRequiredMixin, abstract.TemplateView):
             )
 
             if payment_transaction:
-                print(plan_cost_form.cleaned_data['plan_cost'])
                 # Payment successful - can handle subscription processing
                 subscription = self.setup_subscription(
                     request.user, plan_cost_form.cleaned_data['plan_cost']

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -45,5 +45,16 @@ def pytest_configure():
     django.setup()
 
 @pytest.fixture
-def subscription():
-    return factories.SubscriptionFactory()
+def plan_list():
+    """Fixture that returns PlanList and all related models."""
+    plan_list = factories.PlanListFactory()
+    plan_detail = plan_list.plan_details.first()
+    plan = plan_detail.plan
+    cost = plan.costs.first()
+
+    return {
+        'plan_list': plan_list,
+        'plan_detail': plan_detail,
+        'plan': plan,
+        'cost': cost,
+    }

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,6 +2,10 @@
 import django
 from django.conf import settings
 
+import pytest
+
+from . import factories
+
 
 def pytest_configure():
     """Setups initial testing configuration."""
@@ -39,3 +43,7 @@ def pytest_configure():
 
     # Initiate Django
     django.setup()
+
+@pytest.fixture
+def subscription():
+    return factories.SubscriptionFactory()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,9 +4,6 @@ from django.conf import settings
 
 import pytest
 
-from . import factories
-
-
 def pytest_configure():
     """Setups initial testing configuration."""
     # Setup the bare minimum Django settings
@@ -45,16 +42,29 @@ def pytest_configure():
     django.setup()
 
 @pytest.fixture
-def plan_list():
-    """Fixture that returns PlanList and all related models."""
+def user():
+    """Returns a user model instance."""
+    from . import factories
+
+    return factories.UserFactory()
+
+@pytest.fixture
+def dfs_details():
+    """Fixture that returns all required models for testing DFS."""
+    from . import factories
+
     plan_list = factories.PlanListFactory()
-    plan_detail = plan_list.plan_details.first()
+    plan_detail = plan_list.plan_list_details.first()
     plan = plan_detail.plan
     cost = plan.costs.first()
+    user_instance = factories.UserFactory()
+    subscription = factories.create_subscription(user_instance, cost)
 
     return {
         'plan_list': plan_list,
-        'plan_detail': plan_detail,
+        'plan_list_detail': plan_detail,
         'plan': plan,
         'cost': cost,
+        'user': user_instance,
+        'subscription': subscription,
     }

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -42,29 +42,8 @@ def pytest_configure():
     django.setup()
 
 @pytest.fixture
-def user():
-    """Returns a user model instance."""
-    from . import factories
-
-    return factories.UserFactory()
-
-@pytest.fixture
-def dfs_details():
+def dfs():
     """Fixture that returns all required models for testing DFS."""
     from . import factories
 
-    plan_list = factories.PlanListFactory()
-    plan_detail = plan_list.plan_list_details.first()
-    plan = plan_detail.plan
-    cost = plan.costs.first()
-    user_instance = factories.UserFactory()
-    subscription = factories.create_subscription(user_instance, cost)
-
-    return {
-        'plan_list': plan_list,
-        'plan_list_detail': plan_detail,
-        'plan': plan,
-        'cost': cost,
-        'user': user_instance,
-        'subscription': subscription,
-    }
+    return factories.DFS()

--- a/tests/factories.py
+++ b/tests/factories.py
@@ -23,16 +23,13 @@ class SubscriptionPlanFactory(factory.django.DjangoModelFactory):
     plan_name = factory.Sequence(lambda n: 'Plan {}'.format(n))
     plan_description = factory.Sequence(lambda n: 'Description {}'.format(n))
     grace_period = factory.sequence(lambda n: int(n))
-
-    costs1 = factory.RelatedFactory(PlanCostFactory, 'plan')
-    costs2 = factory.RelatedFactory(PlanCostFactory, 'plan')
+    cost = factory.RelatedFactory(PlanCostFactory, 'plan')
 
     class Meta:
         model = models.SubscriptionPlan
 
 class PlanListDetailFactory(factory.django.DjangoModelFactory):
     """Factory to create a PlanListDetail and related SubscriptionPlan."""
-    plan = factory.SubFactory(SubscriptionPlanFactory)
     html_content = factory.Sequence(lambda n: '<b>{}</b>'.format(n))
     subscribe_button_text = factory.Sequence(lambda n: 'Button {}'.format(n))
     order = factory.Sequence(lambda n: int(n))
@@ -47,13 +44,6 @@ class PlanListFactory(factory.django.DjangoModelFactory):
     header = factory.Sequence(lambda n: 'Header {}'.format(n))
     footer = factory.Sequence(lambda n: 'Footer {}'.format(n))
     active = True
-
-    plan_list_details1 = factory.RelatedFactory(
-        PlanListDetailFactory, 'plan_list'
-    )
-    plan_list_details2 = factory.RelatedFactory(
-        PlanListDetailFactory, 'plan_list'
-    )
 
     class Meta:
         model = models.PlanList
@@ -74,15 +64,119 @@ class UserFactory(factory.django.DjangoModelFactory):
 
         return manager.create_user(*args, **kwargs)
 
-def create_subscription(user, cost):
-    """Creates a usser subscription."""
-    return models.UserSubscription.objects.create(
-        user=user,
-        subscription=cost,
-        date_billing_start=datetime(2018, 1, 1, 1, 1, 1),
-        date_billing_end=None,
-        date_billing_last=datetime(2018, 1, 1, 1, 1, 1),
-        date_billing_next=datetime(2018, 2, 1, 1, 1, 1),
-        active=True,
-        cancelled=False,
-    )
+class DFS:
+    """Object to manage various model instances as needed."""
+    def __init__(self):
+        self._plan_list = None
+        self._plan_list_detail = None
+        self._plan = None
+        self._cost = None
+        self._subscription = None
+        self._user = None
+
+    @property
+    def plan_list(self):
+        """Returns the plan list instance."""
+        # Create a PlanList instance if needed
+        if self._plan_list:
+            return self._plan_list
+
+        # Create the PlanList instance
+        self._plan_list = PlanListFactory()
+
+        # Create the Subscription Plans
+        plan_1 = SubscriptionPlanFactory()
+        plan_2 = SubscriptionPlanFactory()
+        plan_3 = SubscriptionPlanFactory()
+
+        # Create the PlanList Details
+        detail = PlanListDetailFactory(plan_list=self._plan_list, plan=plan_1)
+        PlanListDetailFactory(plan_list=self._plan_list, plan=plan_2)
+        PlanListDetailFactory(plan_list=self._plan_list, plan=plan_3)
+
+        # Update the object attributes
+        self._plan_list_detail = detail
+        self._plan = plan_1
+        self._cost = plan_1.costs.first()
+
+        return self._plan_list
+
+    @property
+    def plan_list_detail(self):
+        """Creates a PlanListDetail instance and associated models."""
+        if self._plan_list_detail:
+            return self._plan_list_detail
+
+        # Create the model references
+        self._plan_list_detail = PlanListDetailFactory()
+        plan = SubscriptionPlanFactory()
+
+        # pylint: disable=attribute-defined-outside-init
+        self._plan_list_detail.plan = plan
+        self._plan_list_detail.save()
+
+        # Update the object attributes
+        self._plan = plan
+        self._cost = plan.costs.first()
+
+        return self._plan_list_detail
+
+    @property
+    def plan(self):
+        """Creates a SubscriptionPlan instance and associated models."""
+        if self._plan:
+            return self._plan
+
+        self._plan = SubscriptionPlanFactory()
+
+        # Update the object attributes
+        self._cost = self._plan.costs.first()
+
+        return self._plan
+
+    @property
+    def cost(self):
+        """Creates a Cost instance and associated models."""
+        if self._cost:
+            return self._cost
+
+        # Create a plan instance to retrieve the cost from
+        self._plan # pylint: disable=pointless-statement
+        self._cost = self._plan.costs.first()
+
+        return self._cost
+
+    @property
+    def user(self):
+        """Returns the user instance."""
+        if not self._user:
+            self._user = UserFactory()
+
+        return self._user
+
+    @property
+    def subscription(self):
+        """Returns a UserSubscription instance."""
+        if self._subscription:
+            return self._subscription
+
+        # Create user if needed
+        if not self._user:
+            self.user # pylint: disable=pointless-statement
+
+        # Create PlanCost if needed
+        if not self._cost:
+            self.plan # pylint: disable=pointless-statement
+
+        self._subscription = models.UserSubscription.objects.create(
+            user=self._user,
+            subscription=self._cost,
+            date_billing_start=datetime(2018, 1, 1, 1, 1, 1),
+            date_billing_end=None,
+            date_billing_last=datetime(2018, 1, 1, 1, 1, 1),
+            date_billing_next=datetime(2018, 2, 1, 1, 1, 1),
+            active=True,
+            cancelled=False,
+        )
+
+        return self._subscription

--- a/tests/factories.py
+++ b/tests/factories.py
@@ -1,10 +1,88 @@
 """Factories to create Subscription Plans."""
+# pylint: disable=unnecessary-lambda
+from datetime import datetime
+
 import factory
+
+from django.contrib.auth import get_user_model
 
 from subscriptions import models
 
 
+class PlanCostFactory(factory.django.DjangoModelFactory):
+    """Factory to create PlanCost model instance."""
+    recurrence_period = factory.Sequence(lambda n: int(n))
+    recurrence_unit = 4
+    cost = factory.Sequence(lambda n: int(n))
+
+    class Meta:
+        model = models.PlanCost
+
+class SubscriptionPlanFactory(factory.django.DjangoModelFactory):
+    """Factory to create SubscriptionPlan and PlanCost models."""
+    plan_name = factory.Sequence(lambda n: 'Plan {}'.format(n))
+    plan_description = factory.Sequence(lambda n: 'Description {}'.format(n))
+    grace_period = factory.sequence(lambda n: int(n))
+
+    costs1 = factory.RelatedFactory(PlanCostFactory, 'plan')
+    costs2 = factory.RelatedFactory(PlanCostFactory, 'plan')
+
+    class Meta:
+        model = models.SubscriptionPlan
+
+class PlanListDetailFactory(factory.django.DjangoModelFactory):
+    """Factory to create a PlanListDetail and related SubscriptionPlan."""
+    plan = factory.SubFactory(SubscriptionPlanFactory)
+    html_content = factory.Sequence(lambda n: '<b>{}</b>'.format(n))
+    subscribe_button_text = factory.Sequence(lambda n: 'Button {}'.format(n))
+    order = factory.Sequence(lambda n: int(n))
+
+    class Meta:
+        model = models.PlanListDetail
+
 class PlanListFactory(factory.django.DjangoModelFactory):
     """Factory to create a PlanList and all related models."""
+    title = factory.Sequence(lambda n: 'Plan List {}'.format(n))
+    subtitle = factory.Sequence(lambda n: 'Subtitle {}'.format(n))
+    header = factory.Sequence(lambda n: 'Header {}'.format(n))
+    footer = factory.Sequence(lambda n: 'Footer {}'.format(n))
+    active = True
+
+    plan_list_details1 = factory.RelatedFactory(
+        PlanListDetailFactory, 'plan_list'
+    )
+    plan_list_details2 = factory.RelatedFactory(
+        PlanListDetailFactory, 'plan_list'
+    )
+
     class Meta:
         model = models.PlanList
+
+class UserFactory(factory.django.DjangoModelFactory):
+    """Creates a user model instance."""
+    username = factory.Sequence(lambda n: 'User {}'.format(n))
+    email = factory.Sequence(lambda n: 'user_{}@email.com'.format(n))
+    password = 'password'
+
+    class Meta:
+        model = get_user_model()
+
+    @classmethod
+    def _create(cls, model_class, *args, **kwargs):
+        """Override _create to use the create_user method."""
+        manager = cls._get_manager(model_class)
+
+        return manager.create_user(*args, **kwargs)
+
+def create_subscription(user, cost):
+    """Creates a usser subscription."""
+    return models.UserSubscription.objects.create(
+        user=user,
+        subscription=cost,
+        date_billing_start=datetime(2018, 1, 1, 1, 1, 1),
+        date_billing_end=None,
+        date_billing_last=datetime(2018, 1, 1, 1, 1, 1),
+        date_billing_next=datetime(2018, 2, 1, 1, 1, 1),
+        active=True,
+        cancelled=False,
+    )

--- a/tests/factories.py
+++ b/tests/factories.py
@@ -4,5 +4,7 @@ import factory
 from subscriptions import models
 
 
-class SubscriptionFactory(factory.django.DjangoModelFactory):
-    pass
+class PlanListFactory(factory.django.DjangoModelFactory):
+    """Factory to create a PlanList and all related models."""
+    class Meta:
+        model = models.PlanList

--- a/tests/factories.py
+++ b/tests/factories.py
@@ -1,0 +1,8 @@
+"""Factories to create Subscription Plans."""
+import factory
+
+from subscriptions import models
+
+
+class SubscriptionFactory(factory.django.DjangoModelFactory):
+    pass

--- a/tests/subscriptions/test_views_subscribe.py
+++ b/tests/subscriptions/test_views_subscribe.py
@@ -13,6 +13,8 @@ from django.utils import timezone
 from subscriptions import models, views, forms
 
 
+pytestmark = pytest.mark.django_db #pylint: disable=invalid-name
+
 def create_plan(plan_name='1', plan_description='2'):
     """Creates and returns SubscriptionPlan instance."""
     return models.SubscriptionPlan.objects.create(
@@ -52,7 +54,6 @@ def create_plan_list(title='test'):
 
 # SubscribeList Tests
 # -----------------------------------------------------------------------------
-@pytest.mark.django_db
 def test_subscribe_list_template(admin_client):
     """Tests for proper subscribe_list template."""
     # Create plan to allow viewing of page
@@ -66,7 +67,6 @@ def test_subscribe_list_template(admin_client):
         ]
     )
 
-@pytest.mark.django_db
 def test_subscribe_list_200_for_anonymous_user(client, django_user_model):
     """Tests for 200 response for anonymous user"""
     # Create plan to allow viewing of page
@@ -81,7 +81,6 @@ def test_subscribe_list_200_for_anonymous_user(client, django_user_model):
 
     assert response.status_code == 200
 
-@pytest.mark.django_db
 def test_subscribe_list_get_plan_list(admin_client):
     """Tests list retrieves a single active list"""
     plan_list = create_plan_list('1')
@@ -90,7 +89,6 @@ def test_subscribe_list_get_plan_list(admin_client):
 
     assert response.context['plan_list'] == plan_list
 
-@pytest.mark.django_db
 def test_subscribe_list_get_plan_list_from_multiple(admin_client):
     """Tests list retrieves a single active list from multiple."""
     plan_list = create_plan_list('1')
@@ -101,7 +99,6 @@ def test_subscribe_list_get_plan_list_from_multiple(admin_client):
 
     assert response.context['plan_list'] == plan_list
 
-@pytest.mark.django_db
 def test_subscribe_list_get_plan_list_with_inactive(admin_client):
     """Tests list retrieves single active list from multiple + inactive."""
     plan_list_1 = create_plan_list('1')
@@ -114,7 +111,6 @@ def test_subscribe_list_get_plan_list_with_inactive(admin_client):
 
     assert response.context['plan_list'] == plan_list_2
 
-@pytest.mark.django_db
 def test_subscribe_list_get_404_on_no_plans(admin_client):
     """Tests that list returns 404 if no plan lists are created."""
     response = admin_client.get(reverse('dfs_subscribe_list'))
@@ -122,7 +118,6 @@ def test_subscribe_list_get_404_on_no_plans(admin_client):
     assert response.status_code == 404
     assert response.content == b'No subscription plans are available'
 
-@pytest.mark.django_db
 def test_subscribe_list_get_context_data(admin_client):
     """Tests get_context_data adds plan list and detail to context."""
     create_plan_list()
@@ -132,7 +127,6 @@ def test_subscribe_list_get_context_data(admin_client):
     assert 'plan_list' in response.context
     assert 'details' in response.context
 
-@pytest.mark.django_db
 def test_subscribe_list_exclude_plan_with_no_cost(admin_client):
     """Tests that a plan with no cost is excluded."""
     create_plan_list()
@@ -141,7 +135,6 @@ def test_subscribe_list_exclude_plan_with_no_cost(admin_client):
 
     assert not response.context['details']
 
-@pytest.mark.django_db
 def test_subscribe_list_expected_ordering(admin_client):
     """Tests that details are listed in order."""
     plan_list = models.PlanList.objects.create(title='plan list')
@@ -194,7 +187,6 @@ def test_subscribe_view_no_redirect_on_login(client, django_user_model):
 
     assert response.status_code == 200
 
-@pytest.mark.django_db
 def test_subscribe_view_get_object_404_without_plan(admin_client):
     """Tests get_object returns 404 when plan is missing."""
     post_data = {
@@ -235,14 +227,12 @@ def test_subscribe_view_get_success_url():
         '/subscribe/thank-you/11111111-1111-4111-a111-111111111111/'
     )
 
-@pytest.mark.django_db
 def test_subscribe_view_get_405_response(admin_client):
     """Tests that GET returns 405 response."""
     response = admin_client.get(reverse('dfs_subscribe_add'))
 
     assert response.status_code == 405
 
-@pytest.mark.django_db
 def test_subscribe_view_post_preview_200_response(admin_client):
     """Tests post returns 200 response on preview request."""
     plan = create_plan()
@@ -262,7 +252,6 @@ def test_subscribe_view_post_preview_200_response(admin_client):
 
     assert response.status_code == 200
 
-@pytest.mark.django_db
 def test_subscribe_view_post_preview_proper_page(admin_client):
     """Tests preview POST returns proper details."""
     plan = create_plan()
@@ -287,7 +276,6 @@ def test_subscribe_view_post_preview_proper_page(admin_client):
         'subscriptions/subscribe_preview.html' in templates
     )
 
-@pytest.mark.django_db
 def test_subscribe_view_post_preview_added_context(admin_client):
     """Tests preview POST adds required forms to context."""
     plan = create_plan()
@@ -312,7 +300,6 @@ def test_subscribe_view_post_preview_added_context(admin_client):
     assert 'payment_form' in response.context
     assert isinstance(response.context['payment_form'], forms.PaymentForm)
 
-@pytest.mark.django_db
 def test_subscribe_view_post_preview_progress_to_confirmation(admin_client):
     """Tests preview POST progresses to confirmation."""
     plan = create_plan()
@@ -346,7 +333,6 @@ def test_subscribe_view_post_preview_progress_to_confirmation(admin_client):
         'subscriptions/subscribe_confirmation.html' in templates
     )
 
-@pytest.mark.django_db
 def test_subscribe_view_post_preview_to_confirm_invalid(admin_client):
     """Tests invalid preview to confirmation POST returns to preview."""
     plan = create_plan()
@@ -377,7 +363,6 @@ def test_subscribe_view_post_preview_to_confirm_invalid(admin_client):
     assert response.context['confirmation'] is False
     assert 'subscriptions/subscribe_preview.html' in templates
 
-@pytest.mark.django_db
 def test_subscribe_view_post_preview_to_confirm_invalid_values(admin_client):
     """Tests invalid preview that form is repopulated correctly."""
     plan = create_plan()
@@ -409,7 +394,6 @@ def test_subscribe_view_post_preview_to_confirm_invalid_values(admin_client):
     assert 'cardholder_name' not in payment_form.data
     assert payment_form.data['card_number'] == '1111222233334444'
 
-@pytest.mark.django_db
 def test_subscribe_view_post_confirmation_200_response(admin_client):
     """Tests post returns 200 response on confirmation request."""
     plan = create_plan()
@@ -429,7 +413,6 @@ def test_subscribe_view_post_confirmation_200_response(admin_client):
 
     assert response.status_code == 200
 
-@pytest.mark.django_db
 def test_subscribe_view_post_confirm_to_process_valid(admin_client):
     """Tests proper confirmation POST moves to success URL page."""
     plan = create_plan()
@@ -460,7 +443,6 @@ def test_subscribe_view_post_confirm_to_process_valid(admin_client):
 
     assert '/subscribe/thank-you' in url
 
-@pytest.mark.django_db
 def test_subscribe_view_post_confirm_to_process_invalid(admin_client):
     """Tests invalid process POST returns to confirmation."""
     plan = create_plan()
@@ -494,7 +476,6 @@ def test_subscribe_view_post_confirm_to_process_invalid(admin_client):
         'subscriptions/subscribe_preview.html' in templates
     )
 
-@pytest.mark.django_db
 def test_subscribe_view_post_confirm_to_process_invalid_values(admin_client):
     """Tests invalid process POST populates proper values in form."""
     plan = create_plan()
@@ -530,7 +511,6 @@ def test_subscribe_view_post_confirm_to_process_invalid_values(admin_client):
     'subscriptions.views.SubscribeView.process_payment',
     lambda self, **kwargs: False
 )
-@pytest.mark.django_db
 def test_subscribe_view_post_confirm_payment_error(admin_client):
     """Tests handling of payment error from confirmation POST."""
     plan = create_plan()
@@ -565,7 +545,6 @@ def test_subscribe_view_post_confirm_payment_error(admin_client):
     assert messages[0].tags == 'error'
     assert messages[0].message == 'Error processing payment'
 
-@pytest.mark.django_db
 def test_subscribe_view_post_process_200_response(admin_client):
     """Tests post returns 200 response on process request."""
     plan = create_plan()
@@ -597,7 +576,6 @@ def test_subscribe_view_hide_form():
 @patch(
     'subscriptions.utils.timezone.now', lambda: datetime(2018, 1, 1, 1, 1, 1)
 )
-@pytest.mark.django_db
 def test_subscribe_view_record_transaction_without_date(django_user_model):
     """Tests handling of record_transaction without providing a date.
 
@@ -616,7 +594,6 @@ def test_subscribe_view_record_transaction_without_date(django_user_model):
     )
     assert transaction.date_transaction == datetime(2018, 1, 1, 1, 1, 1)
 
-@pytest.mark.django_db
 def test_subscribe_view_record_transaction_with_date(django_user_model):
     """Tests handling of record_transaction with date provided."""
     transaction_count = models.SubscriptionTransaction.objects.all().count()
@@ -633,8 +610,6 @@ def test_subscribe_view_record_transaction_with_date(django_user_model):
     )
     assert transaction.date_transaction == transaction_date
 
-
-@pytest.mark.django_db
 def test_subscribe_view_setup_subscription_user_group(django_user_model):
     """Tests that user is properly added to group."""
     user = django_user_model.objects.create_user(username='a', password='b')
@@ -652,7 +627,6 @@ def test_subscribe_view_setup_subscription_user_group(django_user_model):
     assert user in group.user_set.all()
     assert group.user_set.all().count() == user_count + 1
 
-@pytest.mark.django_db
 def test_subscribe_view_setup_subscription_user_subscription(django_user_model):
     """Tests that user subscription entry is setup properly."""
     sub_count = models.UserSubscription.objects.all().count()
@@ -670,7 +644,6 @@ def test_subscribe_view_setup_subscription_user_subscription(django_user_model):
 
     assert models.UserSubscription.objects.all().count() == sub_count + 1
 
-@pytest.mark.django_db
 def test_subscribe_view_setup_subscription_no_group(django_user_model):
     """Tests that setup handles subscriptions with no groups."""
     user = django_user_model.objects.create_user(username='a', password='b')
@@ -690,7 +663,6 @@ def test_subscribe_view_setup_subscription_no_group(django_user_model):
 
 # SubscribeUserListView Tests
 # -----------------------------------------------------------------------------
-@pytest.mark.django_db
 def test_subscribe_user_list_redirect_anonymous(client):
     """Tests that anonymous users are redirected to login page."""
     response = client.get(reverse('dfs_subscribe_user_list'), follow=True)
@@ -699,7 +671,6 @@ def test_subscribe_user_list_redirect_anonymous(client):
     assert redirect_code == 302
     assert redirect_url == ('/accounts/login/?next=/subscriptions/')
 
-@pytest.mark.django_db
 def test_subscribe_user_list_no_redirect_on_login(client, django_user_model):
     """Tests that logged in users are not redirected."""
     django_user_model.objects.create_user(username='a', password='b')
@@ -708,7 +679,6 @@ def test_subscribe_user_list_no_redirect_on_login(client, django_user_model):
 
     assert response.status_code == 200
 
-@pytest.mark.django_db
 def test_subscribe_user_list_requires_user_owner(client, django_user_model):
     """Tests that logged in user has ownership of subscription plans."""
     user_1 = django_user_model.objects.create_user(username='a', password='b')
@@ -762,7 +732,6 @@ def test_thank_you_view_no_redirect_on_login(client, django_user_model):
 
     assert response.status_code == 200
 
-@pytest.mark.django_db
 def test_thank_you_view_returns_object(client, django_user_model):
     """Tests Thank You view properly returns transaction instance."""
     user = django_user_model.objects.create_user(username='a', password='b')
@@ -793,7 +762,6 @@ def test_thank_you_view_adds_context(client, django_user_model):
 
 # SubscribeCancelView Tests
 # -----------------------------------------------------------------------------
-@pytest.mark.django_db
 def test_cancel_view_redirect_anonymous(client):
     """Tests that anonymous users are redirected to login page."""
     sub_id = models.UserSubscription.objects.create().id
@@ -806,7 +774,6 @@ def test_cancel_view_redirect_anonymous(client):
     assert redirect_url == (
         '/accounts/login/?next=/subscribe/cancel/{}/'.format(sub_id))
 
-@pytest.mark.django_db
 def test_cancel_view_no_redirect_on_login(client, django_user_model):
     """Tests that logged in users are not redirected."""
     user = django_user_model.objects.create_user(username='a', password='b')
@@ -823,7 +790,6 @@ def test_cancel_view_get_success_url():
     view = views.SubscribeCancelView()
     assert view.get_success_url() == '/subscriptions/'
 
-@pytest.mark.django_db
 def test_cancel_post_updates_instance(client, django_user_model):
     """Tests that POST request properly updates subscription instance."""
     user = django_user_model.objects.create_user(username='a', password='b')
@@ -851,7 +817,6 @@ def test_cancel_post_updates_instance(client, django_user_model):
     assert messages[0].tags == 'success'
     assert messages[0].message == 'Subscription successfully cancelled'
 
-@pytest.mark.django_db
 def test_cancel_requires_user_owner(client, django_user_model):
     """Tests that logged in user has ownership of subscription plan."""
     django_user_model.objects.create_user(username='a', password='b')


### PR DESCRIPTION
Initial display of form would trigger error messages inappropriately. Have been fixed.

Have also updated tests with factories to streamline future testing and reduce redundancy.