### PR TITLE
Very minor doc update

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -55,7 +55,7 @@ Add django-flexible-subscriptions to your project
 
     urlpatterns = [
         ...
-        url(r'^subscriptions/', include('subscriptions_urls')),
+        url(r'^subscriptions/', include('subscriptions.urls')),
         url(r'^admin/', include(admin.site.urls), # Optional, but recommended
         ...
     ]


### PR DESCRIPTION
Found a small typo in the docs related to registering URLs in the django project's `urlpatterns` - not a HUGE deal, but thought I'd update and PR back to fix it.