### PR TITLE
Fixing plan reference (needs to reference "subscription" first)

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -6,6 +6,16 @@ Changelog
 Version 0 (Beta)
 ----------------
 
+0.12.1 (2020-May-07)
+====================
+
+Bug Fixes
+---------
+
+* Fixing issue with TransactionDetailView and TransactionListView where
+  templates were referencing ``SubscriptionTransaction.plan`` rather
+  than ``SubscriptionTransaction.subscription.plan``.
+
 0.12.0 (2020-Apr-29)
 ====================
 

--- a/subscriptions/__init__.py
+++ b/subscriptions/__init__.py
@@ -4,7 +4,7 @@ import re
 import warnings
 import django
 
-__version__ = '0.12.0'
+__version__ = '0.12.1'
 
 # Provide DepreciationWarning for older Python versions
 # Have to use sys.version while supporting Python 3.5 to enable testing

--- a/subscriptions/templates/subscriptions/transaction_detail.html
+++ b/subscriptions/templates/subscriptions/transaction_detail.html
@@ -21,7 +21,7 @@
 
   <div>
     <strong>{% trans "Plan" %}:</strong>
-    {% if transaction.plan %}{{ transaction.plan }}{% else %}No plan{% endif %}
+    {% if transaction.subscription %}{{ transaction.subscription.plan }}{% else %}No subscription plan{% endif %}
   </div>
 
   <div>

--- a/subscriptions/templates/subscriptions/transaction_list.html
+++ b/subscriptions/templates/subscriptions/transaction_list.html
@@ -54,7 +54,7 @@
           </div>
           <div>
             <span class="table-title">{% trans "Plan" %}</span>
-            {% if transaction.plan %}{{ transaction.plan }}{% else %}No subscription plan{% endif %}
+            {% if transaction.subscription %}{{ transaction.subscription.plan }}{% else %}No subscription plan{% endif %}
           </div>
           <div>
             <span class="table-title">{% trans "Transaction date" %}</span>


### PR DESCRIPTION
- Fixing issue where the transaction views were referencing `transaction.plan` instead of `transaction.subscription.plan`